### PR TITLE
Add permissions for serverfault.com and superuser.com

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "__MSG_appName__",
-  "version": "0.0.2",
-  "manifest_version": 2,
+  "version": "0.0.3",
+  "manifest_version": 3,
   "description": "__MSG_appDescription__",
   "icons": {
     "16": "images/icon-16.png",
@@ -17,8 +17,10 @@
     ]
   },
   "permissions": [
+    "*://serverfault.com/*",
     "*://stackoverflow.com/*",
-    "*://*.stackexchange.com/*"
+    "*://*.stackexchange.com/*",
+    "*://superuser.com/*"
   ],
   "page_action": {
     "default_icon": {
@@ -33,8 +35,10 @@
   "content_scripts": [
     {
       "matches": [
+        "*://serverfault.com/*",
         "*://stackoverflow.com/*",
-        "*://*.stackexchange.com/*"
+        "*://*.stackexchange.com/*",
+        "*://superuser.com/*"
       ],
       "js": [
         "bower_components/jquery/dist/jquery.js",


### PR DESCRIPTION
It appears that the original "[trilogy](https://stackoverflow.blog/2009/05/31/the-stack-overflow-trilogy/)" of stack exchange sites, stackoverflow, serverfault, and superuser, all have their own domains.

This change adds permissions for serverfault.com and superuser.com so that hot network questions are blocked there as well.

Also includes a version bump.

(btw, thanks Jeff! You've really helped me reclaim some of my focus)